### PR TITLE
Add grid mechanics to Fruit Box game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# untitled
+# Fruit Box Game
 
-A new Flutter project.
+This Flutter mini-game displays a 17×10 grid of numbered apples. Drag on the screen to draw a box. If the apples captured inside add up to exactly **10**, the box turns red and releasing your finger removes those apples and awards one point per apple. A two‑minute gauge on the right counts down the remaining time, so clear as many apples as you can before it empties!
 
 ## Getting Started
 

--- a/lib/fruit_box_game.dart
+++ b/lib/fruit_box_game.dart
@@ -1,0 +1,300 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+class FruitBoxGame extends StatefulWidget {
+  const FruitBoxGame({super.key});
+
+  @override
+  State<FruitBoxGame> createState() => _FruitBoxGameState();
+}
+
+class _FruitBoxGameState extends State<FruitBoxGame> {
+  static const int rows = 17;
+  static const int cols = 10;
+  static const Duration gameDuration = Duration(minutes: 2);
+
+  late List<List<int?>> _apples;
+  Timer? _timer;
+  Duration _timeLeft = gameDuration;
+  bool _playing = false;
+  bool _gameOver = false;
+  int _score = 0;
+
+  Offset? _dragStart;
+  Offset? _dragCurrent;
+
+  @override
+  void initState() {
+    super.initState();
+    _generateApples();
+  }
+
+  void _generateApples() {
+    final rng = Random();
+    _apples = List.generate(
+      rows,
+      (_) => List.generate(cols, (_) => rng.nextInt(9) + 1),
+    );
+  }
+
+  void _startGame() {
+    setState(() {
+      _score = 0;
+      _timeLeft = gameDuration;
+      _gameOver = false;
+      _playing = true;
+      _generateApples();
+      _timer?.cancel();
+      _timer = Timer.periodic(const Duration(seconds: 1), (_) {
+        setState(() {
+          if (_timeLeft > Duration.zero) {
+            _timeLeft -= const Duration(seconds: 1);
+            if (_timeLeft <= Duration.zero) {
+              _playing = false;
+              _gameOver = true;
+              _timer?.cancel();
+            }
+          }
+        });
+      });
+    });
+  }
+
+  void _endDrag() {
+    if (_dragStart == null || _dragCurrent == null) return;
+    final rect = Rect.fromPoints(_dragStart!, _dragCurrent!);
+    final selected = <Point<int>>[];
+    int sum = 0;
+    final size = context.size;
+    if (size == null) return;
+    final cellW = size.width - 40;
+    final cellH = size.height;
+    final w = cellW / cols;
+    final h = cellH / rows;
+    for (int r = 0; r < rows; r++) {
+      for (int c = 0; c < cols; c++) {
+        final val = _apples[r][c];
+        if (val == null) continue;
+        final appleRect = Rect.fromLTWH(c * w, r * h, w, h);
+        if (rect.overlaps(appleRect)) {
+          selected.add(Point(c, r));
+          sum += val;
+        }
+      }
+    }
+    if (sum == 10) {
+      for (final p in selected) {
+        if (_apples[p.y][p.x] != null) {
+          _apples[p.y][p.x] = null;
+          _score += 1;
+        }
+      }
+    }
+    _dragStart = null;
+    _dragCurrent = null;
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {
+        if (!_playing) _startGame();
+      },
+      onPanStart: _playing
+          ? (d) => setState(() {
+                _dragStart = d.localPosition;
+                _dragCurrent = d.localPosition;
+              })
+          : null,
+      onPanUpdate: _playing
+          ? (d) => setState(() => _dragCurrent = d.localPosition)
+          : null,
+      onPanEnd: _playing
+          ? (_) => setState(() {
+                _endDrag();
+              })
+          : null,
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final width = constraints.maxWidth - 40;
+          final height = constraints.maxHeight;
+          final cellW = width / cols;
+          final cellH = height / rows;
+
+          Rect? dragRect;
+          bool valid = false;
+          if (_dragStart != null && _dragCurrent != null) {
+            dragRect = Rect.fromPoints(_dragStart!, _dragCurrent!);
+            int sum = 0;
+            for (int r = 0; r < rows; r++) {
+              for (int c = 0; c < cols; c++) {
+                final val = _apples[r][c];
+                if (val == null) continue;
+                final appleRect = Rect.fromLTWH(c * cellW, r * cellH, cellW, cellH);
+                if (dragRect.overlaps(appleRect)) {
+                  sum += val;
+                }
+              }
+            }
+            valid = sum == 10;
+          }
+
+          return Stack(
+            children: [
+              for (int r = 0; r < rows; r++)
+                for (int c = 0; c < cols; c++)
+                  if (_apples[r][c] != null)
+                    Positioned(
+                      left: c * cellW,
+                      top: r * cellH,
+                      width: cellW,
+                      height: cellH,
+                      child: _Apple(value: _apples[r][c]!),
+                    ),
+              if (dragRect != null)
+                Positioned.fromRect(
+                  rect: dragRect,
+                  child: Container(
+                    decoration: BoxDecoration(
+                      border: Border.all(color: valid ? Colors.red : Colors.brown, width: 2),
+                      color: valid ? Colors.red.withOpacity(0.2) : Colors.brown.withOpacity(0.1),
+                    ),
+                  ),
+                ),
+              Positioned(
+                top: 20,
+                left: 20,
+                child: Text(
+                  'Score: \$_score',
+                  style: const TextStyle(fontSize: 20, color: Colors.black),
+                ),
+              ),
+              Positioned(
+                top: 0,
+                right: 0,
+                width: 20,
+                height: height,
+                child: Container(
+                  alignment: Alignment.bottomCenter,
+                  decoration: BoxDecoration(border: Border.all(color: Colors.black)),
+                  child: FractionallySizedBox(
+                    heightFactor: _timeLeft.inMilliseconds / gameDuration.inMilliseconds,
+                    alignment: Alignment.bottomCenter,
+                    child: Container(color: Colors.green),
+                  ),
+                ),
+              ),
+              if (!_playing)
+                Positioned.fill(
+                  child: Container(
+                    color: Colors.white.withOpacity(0.8),
+                    child: Center(
+                      child: Text(
+                        _gameOver ? 'Game Over\nTap to Restart' : 'Tap to Start',
+                        textAlign: TextAlign.center,
+                        style: const TextStyle(fontSize: 28, color: Colors.black),
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _Apple extends StatelessWidget {
+  final int value;
+  const _Apple({required this.value});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          CustomPaint(
+            painter: _ApplePainter(),
+          ),
+          Text(
+            '$value',
+            style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ApplePainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()..color = Colors.red.shade700;
+    final path = Path();
+    path.moveTo(size.width * 0.5, size.height * 0.2);
+    path.cubicTo(
+      size.width * 0.8,
+      0,
+      size.width,
+      size.height * 0.6,
+      size.width * 0.5,
+      size.height,
+    );
+    path.cubicTo(
+      0,
+      size.height * 0.6,
+      size.width * 0.2,
+      0,
+      size.width * 0.5,
+      size.height * 0.2,
+    );
+    canvas.drawPath(path, paint);
+
+    final highlight = Paint()..color = Colors.white.withOpacity(0.3);
+    canvas.drawCircle(
+      Offset(size.width * 0.35, size.height * 0.35),
+      size.width * 0.15,
+      highlight,
+    );
+
+    final leafPaint = Paint()..color = Colors.green.shade600;
+    final leafPath = Path();
+    leafPath.moveTo(size.width * 0.55, size.height * 0.15);
+    leafPath.quadraticBezierTo(
+      size.width * 0.7,
+      size.height * -0.05,
+      size.width * 0.65,
+      size.height * 0.25,
+    );
+    leafPath.quadraticBezierTo(
+      size.width * 0.6,
+      size.height * 0.05,
+      size.width * 0.55,
+      size.height * 0.15,
+    );
+    canvas.drawPath(leafPath, leafPaint);
+
+    final stemPaint = Paint()
+      ..color = Colors.brown
+      ..strokeWidth = size.width * 0.05
+      ..strokeCap = StrokeCap.round;
+    canvas.drawLine(
+      Offset(size.width * 0.5, size.height * 0.2),
+      Offset(size.width * 0.5, size.height * 0.05),
+      stemPaint,
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'fruit_box_game.dart';
 
 void main() {
   runApp(const MyApp());
@@ -31,95 +32,8 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      home: const FruitBoxGame(),
     );
   }
 }
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text(
-              'You have pushed the button this many times:',
-            ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
-    );
-  }
-}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -11,20 +11,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:untitled/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('FruitBoxGame shows initial score', (WidgetTester tester) async {
+    // Build the game and trigger a frame.
     await tester.pumpWidget(const MyApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // The score should start at 0.
+    expect(find.textContaining('Score: 0'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- redesign `FruitBoxGame` with 17×10 numbered apples
- remove apples whose values add up to 10 when boxed during a drag
- show a two-minute timer gauge and running score
- clarify README with the new gameplay description

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6878600a99688322b4a8916cd67631e8